### PR TITLE
Improve clone/checkout/build logic

### DIFF
--- a/features/mpas_tasks.py
+++ b/features/mpas_tasks.py
@@ -68,26 +68,71 @@ def setup_test_environment(step):
 	# Setup both "trusted" and "testing" code directories.  This loop ensures they are setup identically.
 	for testtype in ('trusted', 'testing'):
 
+		print '----------------------------'
+
 		# Clone repo
 		# MH: Below I've switched to checkout a detached head rather than making a local branch.
 		# Making a local branch failed if the branch name already existed (i.e., with 'master' which is automatically created during the clone)
-		if not os.path.exists("%s/%s"%(base_dir, testtype)):
-			print "Clone " + testtype + " version. "
+
+		try:
+			os.chdir("%s/%s"%(base_dir, testtype))
+			HEAD_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD'], stderr=dev_null)
+			need_to_clone = False # if the dir exists AND we got a hash, then this directory is a git repo
+		except:
+			need_to_clone = True  # if we fail to enter the dir or fail to get a hash then call this directory bad
+		os.chdir(base_dir) # return to basedir in case not already there
+
+		if need_to_clone:
+			need_to_build = True # set this for later - we definitely need to build if we don't even have a clone...
+			# delete dir if it exists
+			if os.path.exists("%s/%s"%(base_dir, testtype)):
+				shutil.rmtree("%s/%s"%(base_dir, testtype))
+
+			# Clone repo specified
+			print "Cloning " + testtype + " respository. "
 			command = "git"
 			arg1 = "clone"
 			arg2 = "%s"%configParser.get(testtype+"_repo", "url")
 			arg3 = testtype
 			subprocess.check_call([command, arg1, arg2, arg3], stdout=dev_null, stderr=dev_null)
 			os.chdir("%s/%s"%(base_dir, testtype))
+			print "Checking out " + testtype + " branch. "
 			command = "git"
 			arg1 = "checkout"
 			arg2 = "origin/%s"%configParser.get(testtype+"_repo", "branch")
 			subprocess.check_call([command, arg1, arg2], stdout=dev_null, stderr=dev_null)  # this version checks out a detached head
-			os.chdir("%s"%(base_dir))
+			os.chdir(base_dir) # return to basedir in case not already there
+
+		# ---- Didn't need to make a new clone -----
+		else:  # We don't need to clone, but that doesn't mean the branch or the executable are up to date
+			os.chdir("%s/%s"%(base_dir, testtype))
+			# make a temporary remote to get the most current version of the specified repo
+			remotes = subprocess.check_output(['git', 'remote'], stderr=dev_null)
+			if 'statuscheck' in remotes:
+				# need to delete this remote first
+				subprocess.check_call(['git', 'remote', 'remove', 'statuscheck'], stdout=dev_null, stderr=dev_null)
+			subprocess.check_call(['git', 'remote', 'add', 'statuscheck', "%s"%configParser.get(testtype+"_repo", "url")], stdout=dev_null, stderr=dev_null)
+			subprocess.check_call(['git', 'fetch', 'statuscheck'], stdout=dev_null, stderr=dev_null)
+			# get the hash of the specified branch
+			requested_hash = subprocess.check_output(['git', 'rev-parse', "statuscheck/%s"%configParser.get(testtype+"_repo", "branch")], stderr=dev_null)
+			if requested_hash == HEAD_hash:
+				print 'Current ' + testtype + ' clone and branch are up to date.'
+				need_to_build = False
+				# Now remove the remote
+				subprocess.check_call(['git', 'remote', 'remove', 'statuscheck'], stdout=dev_null, stderr=dev_null)
+			else:
+				print 'Updating ' + testtype + ' HEAD to specified repository and branch.'
+				need_to_build = True
+				# Checkout the specified branch (as detached head) because it either is a different URL/branch or is newer (or older) than the current detached head
+				subprocess.check_call(['git', 'checkout', "statuscheck/%s"%configParser.get(testtype+"_repo", "branch")], stdout=dev_null, stderr=dev_null)
+				# Set the new remote to be 'origin'
+				subprocess.check_call(['git', 'remote', 'remove', 'origin'], stdout=dev_null, stderr=dev_null)
+				subprocess.check_call(['git', 'remote', 'rename', 'statuscheck', 'origin'], stdout=dev_null, stderr=dev_null)
+			os.chdir(base_dir) # return to basedir in case not already there
 
 		# Build executable
-		if not os.path.exists("%s/%s/%s_model"%(base_dir, testtype, world.core)):
-			print "Build " + testtype + " version. "
+		if need_to_build or not os.path.exists("%s/%s/%s_model"%(base_dir, testtype, world.core)):
+			print "Building " + testtype + " executable. "
 			os.chdir("%s/%s"%(base_dir, testtype))
 			args = ["make",]
 			args.append("%s"%world.compiler)
@@ -102,7 +147,9 @@ def setup_test_environment(step):
 				world.testing_executable = "%s/%s_model"%(os.getcwd(), world.core)
 			os.chdir("%s"%(base_dir))
 
+	print '----------------------------'
 	print "/n" #}}}
+
 
 @step('I perform a (\d+) processor MPAS "([^"]*)" run')#{{{
 def run_mpas(step, procs, executable):

--- a/lettuce.landice
+++ b/lettuce.landice
@@ -1,17 +1,19 @@
 [building]
 compiler = gfortran
 core = landice
-flags = ALBANY=true
+#flags = ALBANY=true
 
 [trusted_repo]
 url = git@github.com:MPAS-Dev/MPAS-Release.git
 branch = master
-#test_cases_url = http://oceans11.lanl.gov/mpas_data/mpas_landice/test_cases/release_2.0
-test_cases_url = https://dl.dropboxusercontent.com/u/30481359/
+#url = git@github.com:MPAS-Dev/MPAS.git
+#branch = landice/develop
+test_cases_url = http://oceans11.lanl.gov/mpas_data/mpas_landice/test_cases/release_3.0
 
 [testing_repo]
-url = git@github.com:matthewhoffman/MPAS.git
-branch = landice/add_extern_dycore_interface_v3
-#test_cases_url = http://oceans11.lanl.gov/mpas_data/mpas_landice/test_cases/release_2.0
-test_cases_url = https://dl.dropboxusercontent.com/u/30481359/
+url = git@github.com:MPAS-Dev/MPAS.git
+branch = landice/develop
+#url = git@github.com:mperego/MPAS.git
+#branch = landice/add_extern_dycore_interface_v3
+test_cases_url = http://oceans11.lanl.gov/mpas_data/mpas_landice/test_cases/release_3.0
 


### PR DESCRIPTION
Now lettuce checks if a clone already exists and if it does, if its HEAD
matches the head of the requested repo and branch.  This means if you
change either the branch or the repo url in the config file, lettuce
will update the checkout and rebuild the model.  Similarly, even if you
haven't changed those things, but the version on the remote repo _has_
changed, lettuce will update the checkout and rebuild the model.

lettuce will always checkout the desired branch as a detached head and
leave a single remote called origin that is the source of that detached
head.

If the repo directory does not exist or does not have a valid git repo
in it, a fresh clone is made.

This logic should give the desired behavior for both automated nighly
testing mode and 'interactive' manual sessions with lettuce.

I've tested most of the possible combinations and it appears to work as
advertised.  It does write a bit more information to stdout than before,
but personally I like to know what it did to the repo, if anything.

(Also minor updates to LI setup to get it working again.)
